### PR TITLE
Parametrise php version

### DIFF
--- a/ansible/group_vars/harvesterservers
+++ b/ansible/group_vars/harvesterservers
@@ -4,6 +4,8 @@ nkr_app_name: RecordManager
 nkr_harvester_base_path:       "/usr/local/{{ nkr_app_name }}"
 nkr_harvester_src_path:    "{{ nkr_harvester_base_path }}/src"
 
+php_version:            "73"
+
 index_ip_list:          "{{ secrets.indexservers.internal_ips }}"
 index_host_list:        "{{ secrets.proxyservers.flask_app.index_hosts }}"
 

--- a/ansible/roles/finna-record-manager/tasks/main.yml
+++ b/ansible/roles/finna-record-manager/tasks/main.yml
@@ -14,19 +14,19 @@
     host_list: "{{ index_host_list }}"
   when: deployment_environment_id in ['test', 'pentest']
 
-# repo for rh-php71
+# repo for rh-php
 - name: Install centos-release-scl software collections
   shell: yum -y install centos-release-scl warn=false
 
-- name: Install PHP 7.1
+- name: Install PHP {{php_version}}
   shell: "yum -y install {{ item }} warn=false"
   with_items:
-    - rh-php71
-    - rh-php71-php-pear
-    - rh-php71-php-xml
-    - rh-php71-php-devel
-    - rh-php71-php-mbstring
-    - rh-php71-php-intl
+    - rh-php{{php_version}}
+    - rh-php{{php_version}}-php-pear
+    - rh-php{{php_version}}-php-xml
+    - rh-php{{php_version}}-php-devel
+    - rh-php{{php_version}}-php-mbstring
+    - rh-php{{php_version}}-php-intl
 
 - name: Import mongodb role
   import_role: name=mongodb
@@ -44,13 +44,13 @@
     mode: '655'
 
 - name: Install Composer
-  shell: echo "./install_composer.sh" | scl enable rh-php71 -
+  shell: echo "./install_composer.sh" | scl enable rh-php{{php_version}} -
   args:
     chdir: /usr/local/RecordManager
     creates: /usr/local/RecordManager/vendor
 
 - name: Install requirements with Software Collections enabled PHP
-  shell: echo "./composer.phar install" | scl enable rh-php71 -
+  shell: echo "./composer.phar install" | scl enable rh-php{{php_version}} -
   args:
     chdir: /usr/local/RecordManager
     creates: /usr/local/RecordManager/vendor/autoload.php
@@ -101,7 +101,7 @@
 - block:
 
     - name: Test importing with test EAD xml and print output
-      shell: echo "php import.php --file=/shared/ansible/roles/finna-record-manager/files/test_xmls/julkinen-ead.xml --source=local_ead" | scl enable rh-php71 -
+      shell: echo "php import.php --file=/shared/ansible/roles/finna-record-manager/files/test_xmls/julkinen-ead.xml --source=local_ead" | scl enable rh-php{{php_version}} -
       args:
         chdir: /usr/local/RecordManager
       register: ps
@@ -109,7 +109,7 @@
     - debug: var=ps.stdout_lines
     
     - name: Test updating the Solr index print output
-      shell: echo "php manage.php --func=updatesolr" | scl enable rh-php71 -
+      shell: echo "php manage.php --func=updatesolr" | scl enable rh-php{{php_version}} -
       args:
         chdir: /usr/local/RecordManager
       register: ps2

--- a/ansible/roles/mongodb/tasks/main.yml
+++ b/ansible/roles/mongodb/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Install PECL module for MongoDB
-  shell: yum -y install sclo-php71-php-pecl-mongodb warn=false
+  shell: yum -y install sclo-php{{php_version}}-php-pecl-mongodb warn=false
 
 - name: Ensure that mongodb.ini ok
   ini_file:
-    path: /etc/opt/rh/rh-php71/php.d/50-mongodb.ini
+    path: /etc/opt/rh/rh-php{{php_version}}/php.d/50-mongodb.ini
     section: null
     option: extension
     value: mongodb.so


### PR DESCRIPTION
Also bumped PHP 7.1 -> 7.3 because MongoDB version for PHP 7.1 wasn't available anymore.  If testing this, perhaps keep old VM until confirmed this works. 