### PR TITLE
Fix finna-solr & mongodb roles, delete removed OS users

### DIFF
--- a/ansible/group_vars/indexservers
+++ b/ansible/group_vars/indexservers
@@ -1,4 +1,5 @@
-
+# TODO: some better solution instead this empty string "" definition needed by 'users' role,
+nkr_user: ""
 nkr_app_name: nkr-index
 
 

--- a/ansible/roles/finna-record-manager/tasks/main.yml
+++ b/ansible/roles/finna-record-manager/tasks/main.yml
@@ -3,8 +3,10 @@
 - name: Make sure we have a 'wheel' group
   group: name=wheel state=present
 
+# TODO: role 'users' removes 'nkr-user' and this adds it again. when modifying role 'users' note that indexservers
+# TODO: don't use 'nkr-user'
 - name: Add users that should be able to log in to OS
-  user: name=nkr-user groups=wheel append=yes state=present createhome=yes
+  user: name="{{ nkr_user }}" groups=wheel append=yes state=present createhome=yes
 
 - name: Add index hosts to /etc/hosts
   import_role:

--- a/ansible/roles/finna-solr/tasks/main.yml
+++ b/ansible/roles/finna-solr/tasks/main.yml
@@ -139,10 +139,15 @@
 - name: Start solr service
   service: name=solr state=restarted enabled=yes
 
-# todo best do some looping behavior like when loading testdata
+# 'uri' module interacts with webservices from target host (that's why 'localhost' works)
 - name: Wait for Solr service to start...
-  pause: seconds=10
-
+  uri:
+    url: 'http://localhost:{{ solr.port }}/solr/biblio/select?fl=id&q=*:*&rows=5'
+  retries: 20
+  delay: 1
+  register: solr_response
+  until: solr_response.status == 200
+  run_once: True
 
 - name: Solr cloud - Load core, collection, configuration
   block:
@@ -153,37 +158,27 @@
         SOLR_INCLUDE: /data/solr/vufind/solr.in.finna.sh
 
     - name: Create Solr collection
-      command: "curl 'http://localhost:{{ solr.port }}/solr/admin/collections?action=CREATE&name=biblio&numShards=3&replicationFactor=1&collection.configName=biblio'"
+      uri:
+        url: 'http://localhost:{{ solr.port }}/solr/admin/collections?action=CREATE&name=biblio&numShards=3&replicationFactor=1&collection.configName=biblio'
+      register: solr_response_cr
+      failed_when: solr_response_cr.status != 200 and "collection already exists" not in solr_response_cr.content
 
     - name: Reload Solr configuration
-      command: "curl 'http://localhost:{{ solr.port }}/solr/admin/collections?action=RELOAD&name=biblio'"
+      uri:
+        url: 'http://localhost:{{ solr.port }}/solr/admin/collections?action=RELOAD&name=biblio'
 
   when: secrets.indexservers.solr_cluster == True
   run_once: True
 
-
-- name: Load test data into index
-  block:
-
-    - name: Create directory for testdata
-      file:
-        path: "/data/solr/testdata"
-        state: directory
-
-    # note: ansible automatically looks from files/ directory of the role (on the control machine)
-    - name: Copy testdata.json to /data/solr/testdata
-      copy:
-        src: testdata.json
-        dest: "/data/solr/testdata/testdata.json"
-
-    - name: Load testdata.json into index
-      command: "curl -X POST -H 'Content-Type: application/json' 'http://localhost:{{ solr.port }}/solr/biblio/update' --data-binary @/data/solr/testdata/testdata.json"
-      retries: 3
-      delay: 3
-      register: result
-      until: 'result.stdout_lines and "status\":0" in result.stdout_lines[2]'
-      args:
-        warn: false
-
+- name: Load testdata.json into index
+  uri:
+    url: 'http://localhost:{{ solr.port }}/solr/biblio/update'
+    method: POST
+    body: "{{ lookup('file', 'testdata.json')}}"
+    body_format: json
+  retries: 3
+  delay: 3
+  register: solr_response_u
+  until: solr_response_u.status == 200 and solr_response_u.json.responseHeader.status == 0
   when: deployment_environment_id in ['local_development', 'test']
   run_once: True

--- a/ansible/roles/mongodb/tasks/main.yml
+++ b/ansible/roles/mongodb/tasks/main.yml
@@ -13,7 +13,8 @@
 
 - name: Add MongoDB repo
   shell: yum-config-manager --add-repo https://repo.mongodb.org/yum/redhat/7Server/mongodb-org/4.0/x86_64/ warn=false
-  ignore_errors: true
+  register: yum_mongo_repo
+  failed_when: yum_mongo_repo.rc != 0 and "duplicate of an existing repo" not in yum_mongo_repo.stdout
 
 - name: Download mongodb gpgkey
   get_url:

--- a/ansible/roles/provision_proxy/tasks/main.yml
+++ b/ansible/roles/provision_proxy/tasks/main.yml
@@ -3,8 +3,10 @@
 - name: Make sure we have a 'wheel' group
   group: name=wheel state=present
 
+# TODO: role 'users' removes 'nkr-user' and this adds it again. when modifying role 'users' note that indexservers
+# TODO: don't use 'nkr-user'
 - name: Add users that should be able to log in to OS
-  user: name=nkr-user groups=wheel append=yes state=present createhome=yes
+  user: name="{{ nkr_user }}" groups=wheel append=yes state=present createhome=yes
 
 - name: Add index hosts to /etc/hosts
   import_role:

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -26,4 +26,19 @@
       copy: src=files/public_keys/{{ item }}.pub dest=/home/{{ item }}/.ssh/authorized_keys owner={{ item }} mode=0600
       with_items: "{{ os_users }}"
 
+    - name: Determine existing users
+      shell: 'grep wheel /etc/group | cut -d: -f4 | tr "," "\n"'
+      changed_when: false
+      register: existing_users
+
+    - name: Determine removed users
+      set_fact:
+        removed_users: "{{ existing_users.stdout_lines | difference(ssh_user) | difference(os_users) | difference (nkr_user) }}"
+
+    - name: Delete removed user accounts
+      user:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ removed_users }}"
+
   when: deployment_environment_id != 'local_development'


### PR DESCRIPTION
finna-solr role didn't pass in pentest environment and needed fixing.
Also small improvement to a mongodb task error handling.

Finally it was possible to run whole playbook and provision new users to related machines and prune the old users. So added deleting removed users from target machines.