### PR TITLE
Ansible improvements

### DIFF
--- a/ansible/roles/finna-record-manager/tasks/main.yml
+++ b/ansible/roles/finna-record-manager/tasks/main.yml
@@ -126,6 +126,7 @@
       register: ps
 
     - debug: var=ps.stdout_lines
+    - debug: var=ps.stderr_lines
     
     - name: Test updating the Solr index print output
       shell: echo "php manage.php --func=updatesolr" --source=local_ead | scl enable rh-php{{php_version}} -
@@ -134,6 +135,7 @@
       register: ps2
 
     - debug: var=ps2.stdout_lines
+    - debug: var=ps2.stderr_lines
 
     - name: Clean Solr after test
       shell: echo "php manage.php --func=deletesolr" --source=local_ead | scl enable rh-php{{php_version}} -
@@ -142,6 +144,7 @@
       register: ps3
 
     - debug: var=ps3.stdout_lines
+    - debug: var=ps3.stderr_lines
 
     - name: Clean test EAD after test
       shell: echo "php manage.php --func=deletesource" --source=local_ead | scl enable rh-php{{php_version}} -
@@ -150,6 +153,7 @@
       register: ps4
 
     - debug: var=ps4.stdout_lines
+    - debug: var=ps4.stderr_lines
 
     - name: Set log file permissions for developer CLI usage
       file:

--- a/ansible/roles/finna-record-manager/tasks/main.yml
+++ b/ansible/roles/finna-record-manager/tasks/main.yml
@@ -119,8 +119,13 @@
 
 - block:
 
+    - name: Copy RecordManager test file to development machine
+      copy:
+        src: test_xmls/julkinen-ead.xml
+        dest: /usr/local/RecordManager/julkinen-ead.xml
+
     - name: Test importing with test EAD xml and print output
-      shell: echo "php import.php --file=/shared/ansible/roles/finna-record-manager/files/test_xmls/julkinen-ead.xml --source=local_ead" --verbose| scl enable rh-php{{php_version}} -
+      shell: echo "php import.php --file=/usr/local/RecordManager/julkinen-ead.xml --source=local_ead" --verbose| scl enable rh-php{{php_version}} -
       args:
         chdir: /usr/local/RecordManager
       register: ps

--- a/ansible/secrets/local_development.yml
+++ b/ansible/secrets/local_development.yml
@@ -17,7 +17,7 @@ secrets:
         finna_solr_commit: b319000b24896b4744eb60a34c47e7898bb113f7
         zookeeper:
             client_port: 2181
-            version: 3.6.2
+            version: 3.7.0
         httpd:
             conf_loglevel: debug
             listen_port: 443


### PR DESCRIPTION
- Also print out stderror in the RecordManager tests
- Copy RecordManager test file to dev box
- Bump Zookeeper version to 3.7.0
