### PR TITLE
Switch Zookeeper version to 'stable' instead of 'current'

### DIFF
--- a/ansible/roles/zookeeper/tasks/main.yml
+++ b/ansible/roles/zookeeper/tasks/main.yml
@@ -5,8 +5,7 @@
     name: ansible-zookeeper
   vars:
     data_dir: /data/zookeeper
-    # newer version has "apache-" prefix in .tar.gz filename
-    zookeeper_url: https://downloads.apache.org/zookeeper/current/apache-zookeeper-{{zookeeper_version}}-bin.tar.gz
+    zookeeper_url: "https://archive.apache.org/dist/zookeeper/stable/apache-zookeeper-{{ zookeeper.version }}-bin.tar.gz"
     zookeeper_version: "{{ zookeeper.version }}"
     client_port: "{{ zookeeper.client_port }}"
     zookeeper_hosts: "

--- a/ansible/secrets/local_development.yml
+++ b/ansible/secrets/local_development.yml
@@ -17,7 +17,7 @@ secrets:
         finna_solr_commit: b319000b24896b4744eb60a34c47e7898bb113f7
         zookeeper:
             client_port: 2181
-            version: 3.7.0
+            version: 3.6.3
         httpd:
             conf_loglevel: debug
             listen_port: 443


### PR DESCRIPTION
Bump down Zookeeper version, but use stable instead of latest.
Possibly reduces the need to update the version number too often.
