### PR TITLE
Pouta development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
 
 # nkr-ops
 
-Ansible-scripts to deploy NKR index to remote machines and local development
-(Vagrant or Pouta).
+Ansible-scripts to deploy NKR back end components to remote machines or a
+local or remote development environment.
 
-In case python3 is not yet installed on managed nodes, consider using [this
+In testing/production, the components are deployed on separate servers.
+For development, all the components are deployed on the same machine (local
+virtual machine or remote server).
+
+In case Python 3 is not yet installed on managed nodes, consider using [this
 playbook](https://github.com/CSCfi/ansible-provision-python3) for provisioning
 python3 first.
 
-## Local development with Vagrant
+## Local development environment with Vagrant
 
 After cloning this repo, you need to get the project secrets and edit
 `ansible/secrets/local_development.yml` accordingly. After that you can run the
 following to create and connect to the development VM.
 
-```
+```bash
 vagrant up
 vagrant ssh
 ```
 
 Edit your local `/etc/hosts` file to add:
 
-```
+```bash
 30.30.30.30 nkr-index.csc.local
 30.30.30.30 nkr-proxy.csc.local
 ```
@@ -29,14 +33,14 @@ Edit your local `/etc/hosts` file to add:
 Then, solr ui at: nkr-index.csc.local
 And authz proxy at: nkr-proxy.csc.local
 
-## Local development with Pouta
+## Development on a remote server
 
 After cloning the repo, work in the `ansible/` directory.
 
 First, edit `secrets/local_development.yml` and change the following:
 
 ```yml
-devserver_ip: <public IP of your Pouta instance>
+devserver_ip: <public IP of your development server>
 devserver_user: cloud-user
 devserver_connection: ssh
 ```

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 
 # nkr-ops
 
-Ansible-scripts to deploy NKR index to remote machines and local development (vagrant).
+Ansible-scripts to deploy NKR index to remote machines and local development
+(Vagrant or Pouta).
 
-In case python3 is not yet installed on managed nodes, consider using [this playbook](https://github.com/CSCfi/ansible-provision-python3) for provisioning python3 first.
+In case python3 is not yet installed on managed nodes, consider using [this
+playbook](https://github.com/CSCfi/ansible-provision-python3) for provisioning
+python3 first.
 
-## local development
+## Local development with Vagrant
+
+After cloning this repo, you need to get the project secrets and edit
+`ansible/secrets/local_development.yml` accordingly. After that you can run the
+following to create and connect to the development VM.
 
 ```
-clone https://github.com/CSCfi/nkr-ops
-cd nkr-ops
 vagrant up
 vagrant ssh
 ```
 
-Edit your local /etc/hosts file to add:
+Edit your local `/etc/hosts` file to add:
 
 ```
 30.30.30.30 nkr-index.csc.local
@@ -24,7 +29,28 @@ Edit your local /etc/hosts file to add:
 Then, solr ui at: nkr-index.csc.local
 And authz proxy at: nkr-proxy.csc.local
 
-### authentication in local dev
+## Local development with Pouta
+
+After cloning the repo, work in the `ansible/` directory.
+
+First, edit `secrets/local_development.yml` and change the following:
+
+```yml
+devserver_ip: <public IP of your Pouta instance>
+devserver_user: cloud-user
+devserver_connection: ssh
+```
+
+Then run the playbooks with:
+
+```bash
+ansible-playbook -i inventories/local_development/hosts -e @./secrets/local_development.yml --private-key <path_to_your_keyfile> site_provision.yml
+```
+
+You can do the same edits to `/etc/hosts` as above, with the IP of your
+Pouta instance.
+
+## Authentication in local dev
 
 nkr-index BA credentials: nkr-index / nkr-index
 

--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -1,2 +1,3 @@
 server_ip: 127.0.0.1
 deployment_environment_id: local_development
+dev_user: vagrant

--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -1,3 +1,4 @@
-server_ip: 127.0.0.1
+server_ip: "{{ secrets.devserver_ip }}"
 deployment_environment_id: local_development
-dev_user: vagrant
+dev_user: "{{ secrets.devserver_user }}"
+dev_connection: "{{ secrets.devserver_connection }}"

--- a/ansible/inventories/local_development/hosts
+++ b/ansible/inventories/local_development/hosts
@@ -1,14 +1,14 @@
 [indexservers]
-nkr-index-local ansible_host="{{ server_ip }}" ansible_connection=local ansible_user=vagrant
+nkr-index-local ansible_host="{{ server_ip }}" ansible_connection="{{ dev_connection }}" ansible_user="{{ dev_user }}"
 
 [proxyservers]
-nkr-proxy-local ansible_host="{{ server_ip }}" ansible_connection=local ansible_user=vagrant
+nkr-proxy-local ansible_host="{{ server_ip }}" ansible_connection="{{ dev_connection }}" ansible_user="{{ dev_user }}"
 
 [harvesterservers]
-nkr-harvester-local ansible_host="{{ server_ip }}" ansible_connection=local ansible_user=vagrant
+nkr-harvester-local ansible_host="{{ server_ip }}" ansible_connection="{{ dev_connection }}" ansible_user="{{ dev_user }}"
 
 [distincthosts]
-nkr-local-1 ansible_host="{{ server_ip }}" ansible_connection=local ansible_user=vagrant
+nkr-local-1 ansible_host="{{ server_ip }}" ansible_connection="{{ dev_connection }}" ansible_user="{{ dev_user }}"
 
 [local_development:children]
 indexservers

--- a/ansible/preprovision_devserver.yml
+++ b/ansible/preprovision_devserver.yml
@@ -1,0 +1,8 @@
+---
+- hosts: indexservers
+  become: yes
+  become_user: root
+  roles:
+    - preprovision
+  vars:
+    - ansible_python_interpreter: /usr/bin/python

--- a/ansible/provision_indexservers.yml
+++ b/ansible/provision_indexservers.yml
@@ -3,6 +3,7 @@
 - hosts: indexservers
   become: yes
   roles:
+    - { role: preprovision, when: "deployment_environment_id == 'local_development'" }
     - os-base
     - apache
     - ansible-role-java

--- a/ansible/roles/finna-record-manager/files/vscode_conf/config.ssh-template
+++ b/ansible/roles/finna-record-manager/files/vscode_conf/config.ssh-template
@@ -2,4 +2,4 @@
 Host nkr-index.csc.local
   HostName nkr-index.csc.local
   IdentityFile /path/to/your/"vagrant root"/.vagrant/machines/nkr_local_dev_env/virtualbox/private_key
-  User vagrant
+  User {{ dev_user }}

--- a/ansible/roles/finna-record-manager/tasks/main.yml
+++ b/ansible/roles/finna-record-manager/tasks/main.yml
@@ -163,8 +163,8 @@
     - name: Set log file permissions for developer CLI usage
       file:
         path: /var/log/recman.log
-        owner: vagrant
-        group: vagrant
+        owner: "{{ dev_user }}"
+        group: "{{ dev_user }}"
 
     - name: Copy bash aliases to {{ nkr_user }} user home dir
       template: src=templates/bash_harvester_aliases dest=/home/{{ nkr_user }}/.bash_harvester_aliases owner={{ nkr_user }} group={{ nkr_user }}

--- a/ansible/roles/preprovision/tasks/main.yml
+++ b/ansible/roles/preprovision/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Yum update
+  yum:
+    name: "*"
+    state: latest
+    update_cache: yes
+
+- name: Install stuff from Yum
+  yum:
+    name:
+      - epel-release
+      - libffi-devel
+      - openssl-devel
+      - git
+      - python3
+      - python3-devel
+    state: latest
+
+- name: Upgrade global pip3
+  pip:
+    executable: pip3
+    extra_args: --upgrade
+    name: pip

--- a/ansible/secrets/local_development.yml
+++ b/ansible/secrets/local_development.yml
@@ -4,6 +4,10 @@
 
 secrets:
 
+    devserver_ip: 127.0.0.1
+    devserver_user: vagrant
+    devserver_connection: local
+
     artifactory_username: <copy_these_from_nkr-ops-sec_secrets_for_test>
     artifactory_password: <copy_these_from_nkr-ops-sec_secrets_for_test>
     artifactory_server: <copy_these_from_nkr-ops-sec_secrets_for_test>


### PR DESCRIPTION
Set up development environment provisioning to allow setting up on Pouta

New variables have defaults which correspond to the old Vagrant setup,
so it should still work without any changes.

Commits:

- Parametrize dev username
- Parametrize local development connection
- Add role to "preprovision" development server
- Preprovision automatically, add Pouta instructions to README
