### PR TITLE
Fix preprovisioning of remote dev server

### DIFF
--- a/ansible/provision_indexservers.yml
+++ b/ansible/provision_indexservers.yml
@@ -3,7 +3,6 @@
 - hosts: indexservers
   become: yes
   roles:
-    - { role: preprovision, when: "deployment_environment_id == 'local_development'" }
     - os-base
     - apache
     - ansible-role-java

--- a/ansible/roles/preprovision/tasks/main.yml
+++ b/ansible/roles/preprovision/tasks/main.yml
@@ -6,7 +6,7 @@
     state: latest
     update_cache: yes
 
-- name: Install stuff from Yum
+- name: Install some basic packages from Yum
   yum:
     name:
       - epel-release

--- a/ansible/site_provision.yml
+++ b/ansible/site_provision.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Preprovision remote dev server
+  import_playbook: preprovision_devserver.yml
+  when: "deployment_environment_id == 'local_development'"
+
 - import_playbook: provision_indexservers.yml
 - import_playbook: provision_harvesterservers.yml
 - import_playbook: provision_proxyservers.yml


### PR DESCRIPTION
Now it uses the correct (old) Python interpreter for the preprovision
playbook to install Python 3, before running the actual playbooks using
the Python 3 intepreter.
