### PR TITLE
Fix multiple issues in dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ vagrant ssh
 Edit your local `/etc/hosts` file to add:
 
 ```bash
-30.30.30.30 nkr-index.csc.local
-30.30.30.30 nkr-proxy.csc.local
+10.30.30.30 nkr-index.csc.local
+10.30.30.30 nkr-proxy.csc.local
 ```
 
 Then, solr ui at: nkr-index.csc.local

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,8 @@ end
 Vagrant.configure("2") do |config|
   config.vm.define "nkr_local_dev_env" do |server|
     server.vm.box = "centos/7"
-    server.vm.network :private_network, ip: "30.30.30.30"
+    server.vbguest.installer_options = { allow_kernel_upgrade: true }
+    server.vm.network :private_network, ip: "10.30.30.30"
 
     # Basic VM synced folder mount
     server.vm.synced_folder "./ansible", "/shared/ansible", :mount_options => ["dmode=775,fmode=775"]

--- a/ansible/preprovision_devserver.yml
+++ b/ansible/preprovision_devserver.yml
@@ -4,5 +4,3 @@
   become_user: root
   roles:
     - preprovision
-  vars:
-    - ansible_python_interpreter: /usr/bin/python

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -3,4 +3,4 @@
 - src: https://github.com/cscfi/ansible-role-java
   version: d85609676d5d170f8d912bd1def9443ff60683a8
 - src: https://github.com/cscfi/ansible-zookeeper
-  version: f1995940aee5a14117f506b8cba7403e1e14cf9a
+  version: 07c94c5e6b038af134a5d4a0e3422f0e9c9bbe34

--- a/ansible/roles/preprovision/tasks/main.yml
+++ b/ansible/roles/preprovision/tasks/main.yml
@@ -1,21 +1,17 @@
 ---
 
 - name: Yum update
-  yum:
-    name: "*"
-    state: latest
-    update_cache: yes
+  shell: yum clean expire-cache && yum -y update warn=false
 
 - name: Install some basic packages from Yum
-  yum:
-    name:
-      - epel-release
-      - libffi-devel
-      - openssl-devel
-      - git
-      - python3
-      - python3-devel
-    state: latest
+  shell: "yum -y install {{ item }} warn=false"
+  with_items:
+    - epel-release
+    - libffi-devel
+    - openssl-devel
+    - git
+    - python3
+    - python3-devel
 
 - name: Upgrade global pip3
   pip:

--- a/ansible/roles/provision_proxy/tasks/main.yml
+++ b/ansible/roles/provision_proxy/tasks/main.yml
@@ -81,15 +81,14 @@
     lineinfile:
       dest: "/etc/hosts"
       state: present
-      line: "30.30.30.30 {{ server_domain_name }}"
+      line: "10.30.30.30 {{ server_domain_name }}"
 
   - name: Display additional instructions for local dev environment
     debug:
       msg:
         - "Local dev environment successfully set up. Execute `vagrant ssh` to connect."
         - "For web browser access, open your local /etc/hosts file and add the following entries:"
-        - "30.30.30.30 nkr-index.csc.local"
-        - "30.30.30.30 nkr-harvester.csc.local"
-        - "30.30.30.30 nkr-proxy.csc.local"
+        - "10.30.30.30 nkr-index.csc.local"
+        - "10.30.30.30 nkr-proxy.csc.local"
 
   when: deployment_environment_id == 'local_development'


### PR DESCRIPTION
- Add "{ allow_kernel_upgrade: true }" in Vagrantfile to fix VBGuest Additions missing issue
- Change 30.x.x.x ips to 10.x.x.x ips for truly local ip range
- Remove explicit Python2 usage in pre-provision in favor of customarily
  used implicit Python2 usage by using `shell` module instead of `yum`.
  Explicit Python2 usage was in conflict with `pip` module usage in
  pre-provision role. When updating VM to RHEL8 we can tidy `shell`s to
  `yum` modules.
- Update Ansible requirement.yml for `ansible-zookeeper` role to version
  which fixes "Re-rename amazon.aws.aws_s3 module as aws_s3" issue.